### PR TITLE
Added support for vis events

### DIFF
--- a/components/timeline/vis-timeline.service.ts
+++ b/components/timeline/vis-timeline.service.ts
@@ -130,7 +130,7 @@ export class VisTimelineService {
    */
   public timechanged: EventEmitter<any> = new EventEmitter<any>();
 
-  private events: Map<String, EventEmitter<any>> = new Map();
+  private events: Map<string, EventEmitter<any>> = new Map();
 
   private timelines: { [id: string]: VisTimeline } = {};
 

--- a/components/timeline/vis-timeline.service.ts
+++ b/components/timeline/vis-timeline.service.ts
@@ -130,6 +130,8 @@ export class VisTimelineService {
    */
   public timechanged: EventEmitter<any> = new EventEmitter<any>();
 
+  private events: Map<String, EventEmitter<any>> = new Map();
+
   private timelines: { [id: string]: VisTimeline } = {};
 
   /**
@@ -679,11 +681,11 @@ export class VisTimelineService {
    */
   public on(visTimeline: string, eventName: VisTimelineEvents, preventDefault?: boolean): boolean {
     if (this.timelines[visTimeline]) {
-      /* tslint:disable */
+      this.events.set(eventName, new EventEmitter<any>());
+
       const that: { [index: string]: any } = this;
-      /* tslint:enable */
       this.timelines[visTimeline].on(eventName, (params: any) => {
-        const emitter = that[eventName] as EventEmitter<any>;
+        const emitter = (that[eventName] || that.events.get(eventName)) as EventEmitter<any>;
         if (emitter) {
           emitter.emit(params ? [visTimeline].concat(params) : visTimeline);
         }
@@ -708,8 +710,18 @@ export class VisTimelineService {
    */
   public off(visTimeline: string, eventName: VisTimelineEvents): void {
     if (this.timelines[visTimeline]) {
+      this.events.delete(eventName);
       this.timelines[visTimeline].off(eventName, undefined);
     }
+  }
+
+  /**
+   * Get the event emitter associated with the specified event name.
+   * @param {VisTimelineEvents} eventName The event name.
+   * @returns {EventEmitter<any>} The event emitter of the specified event name.
+   */
+  public getEmitter(eventName: VisTimelineEvents): EventEmitter<any> {
+    return this.events.get(eventName);
   }
 
   private doesNotExistError(visTimeline: string): string {


### PR DESCRIPTION
I've tried to update the vis timeline service to give the ability to use any of the events declared in the vis timeline documentation. Right now, through ngx-vis, you can only use the events specified in the VisTimelineService class, this is fine for common use cases but if you need to use other events (e.g. "mouseOver" or "drop") you'll have an hard time figuring out how to do so.
I already know that my implementation of the feature is not perfect because a new "EventEmitter" is created every time you call the "on" method but if you like the idea i could work on this a bit more and fix it by creating all the necessary event emitters beforehand.
The nice part is that the old implementation (using `visTimelineService.click.subscribe(() => { ... })`) will still work 😊.
I hope you'll consider this pull request.
Thanks in advice.